### PR TITLE
Fix for issue where link and image is repeated

### DIFF
--- a/includes/content-grid-providers/class-standard-content-grid-provider.php
+++ b/includes/content-grid-providers/class-standard-content-grid-provider.php
@@ -140,12 +140,12 @@ class Standard_Content_Grid_Provider extends Base_Content_Grid_Provider implemen
 	 * @return string Content Grid HTML
 	 */
 	public function get_content_grid_html( array $raw_content ) : string {
-		
+
 		$this->title          = $raw_content['title'] ?: null;
 		$this->text           = $raw_content['text'] ?: null;
 		$this->call_to_action = $raw_content['cta'] ?: null;
 		$this->image          = $raw_content['image_id'] ?: null;
-		
+
 		if ( ! empty( $raw_content['image_id'] ) ) {
 			$image = wp_parse_args( apply_filters( 'hogan/module/content_grid/' . $this->get_identifier() . '/image/args', [] ), [
 				'size' => 'medium',
@@ -155,7 +155,7 @@ class Standard_Content_Grid_Provider extends Base_Content_Grid_Provider implemen
 
 			$image['id'] = $raw_content['image_id'];
 			$this->image = $image;
-		} 
+		}
 
 		// Call to action button.
 		if ( ! empty( $raw_content['cta'] ) ) {
@@ -164,7 +164,7 @@ class Standard_Content_Grid_Provider extends Base_Content_Grid_Provider implemen
 			$cta['classname'] = apply_filters( 'hogan/module/banner/cta_css_classes', '', $this );
 
 			$this->call_to_action = $cta;
-		} 
+		}
 
 		return parent::render_template();
 	}

--- a/includes/content-grid-providers/class-standard-content-grid-provider.php
+++ b/includes/content-grid-providers/class-standard-content-grid-provider.php
@@ -140,6 +140,12 @@ class Standard_Content_Grid_Provider extends Base_Content_Grid_Provider implemen
 	 * @return string Content Grid HTML
 	 */
 	public function get_content_grid_html( array $raw_content ) : string {
+		
+		$this->title          = $raw_content['title'];
+		$this->text           = $raw_content['text'];
+		$this->call_to_action = $raw_content['cta'];
+		$this->image          = $raw_content['image_id'];
+		
 		if ( ! empty( $raw_content['image_id'] ) ) {
 			$image = wp_parse_args( apply_filters( 'hogan/module/content_grid/' . $this->get_identifier() . '/image/args', [] ), [
 				'size' => 'medium',
@@ -149,12 +155,7 @@ class Standard_Content_Grid_Provider extends Base_Content_Grid_Provider implemen
 
 			$image['id'] = $raw_content['image_id'];
 			$this->image = $image;
-		} else {
-			$this->image = null;
-		}
-
-		$this->title = $raw_content['title'];
-		$this->text  = $raw_content['text'];
+		} 
 
 		// Call to action button.
 		if ( ! empty( $raw_content['cta'] ) ) {
@@ -163,9 +164,7 @@ class Standard_Content_Grid_Provider extends Base_Content_Grid_Provider implemen
 			$cta['classname'] = apply_filters( 'hogan/module/banner/cta_css_classes', '', $this );
 
 			$this->call_to_action = $cta;
-		} else {
-			$this->call_to_action = null;
-		}
+		} 
 
 		return parent::render_template();
 	}

--- a/includes/content-grid-providers/class-standard-content-grid-provider.php
+++ b/includes/content-grid-providers/class-standard-content-grid-provider.php
@@ -149,6 +149,8 @@ class Standard_Content_Grid_Provider extends Base_Content_Grid_Provider implemen
 
 			$image['id'] = $raw_content['image_id'];
 			$this->image = $image;
+		} else {
+			$this->image = null;
 		}
 
 		$this->title = $raw_content['title'];
@@ -161,6 +163,8 @@ class Standard_Content_Grid_Provider extends Base_Content_Grid_Provider implemen
 			$cta['classname'] = apply_filters( 'hogan/module/banner/cta_css_classes', '', $this );
 
 			$this->call_to_action = $cta;
+		} else {
+			$this->call_to_action = null;
 		}
 
 		return parent::render_template();

--- a/includes/content-grid-providers/class-standard-content-grid-provider.php
+++ b/includes/content-grid-providers/class-standard-content-grid-provider.php
@@ -44,7 +44,7 @@ class Standard_Content_Grid_Provider extends Base_Content_Grid_Provider implemen
 	 *
 	 * @var array|null $call_to_action
 	 */
-	public $call_to_action = null;
+	public $call_to_action;
 
 	/**
 	 * Get provider identifier, i.e. "text"
@@ -141,10 +141,10 @@ class Standard_Content_Grid_Provider extends Base_Content_Grid_Provider implemen
 	 */
 	public function get_content_grid_html( array $raw_content ) : string {
 		
-		$this->title          = $raw_content['title'];
-		$this->text           = $raw_content['text'];
-		$this->call_to_action = $raw_content['cta'];
-		$this->image          = $raw_content['image_id'];
+		$this->title          = $raw_content['title'] ?: null;
+		$this->text           = $raw_content['text'] ?: null;
+		$this->call_to_action = $raw_content['cta'] ?: null;
+		$this->image          = $raw_content['image_id'] ?: null;
 		
 		if ( ! empty( $raw_content['image_id'] ) ) {
 			$image = wp_parse_args( apply_filters( 'hogan/module/content_grid/' . $this->get_identifier() . '/image/args', [] ), [

--- a/includes/content-grid-providers/class-standard-content-grid-provider.php
+++ b/includes/content-grid-providers/class-standard-content-grid-provider.php
@@ -146,7 +146,7 @@ class Standard_Content_Grid_Provider extends Base_Content_Grid_Provider implemen
 		$this->call_to_action = $raw_content['cta'] ?: null;
 		$this->image          = $raw_content['image_id'] ?: null;
 
-		if ( ! empty( $raw_content['image_id'] ) ) {
+		if ( null !== $this->image ) {
 			$image = wp_parse_args( apply_filters( 'hogan/module/content_grid/' . $this->get_identifier() . '/image/args', [] ), [
 				'size' => 'medium',
 				'icon' => false,
@@ -158,7 +158,7 @@ class Standard_Content_Grid_Provider extends Base_Content_Grid_Provider implemen
 		}
 
 		// Call to action button.
-		if ( ! empty( $raw_content['cta'] ) ) {
+		if (  null !== $this->call_to_action ) {
 			$cta              = $raw_content['cta'];
 			$cta['title']     = $cta['title'] ?: __( 'Read more', 'hogan-content-grid' );
 			$cta['classname'] = apply_filters( 'hogan/module/banner/cta_css_classes', '', $this );

--- a/includes/content-grid-providers/class-standard-content-grid-provider.php
+++ b/includes/content-grid-providers/class-standard-content-grid-provider.php
@@ -158,7 +158,7 @@ class Standard_Content_Grid_Provider extends Base_Content_Grid_Provider implemen
 		}
 
 		// Call to action button.
-		if (  null !== $this->call_to_action ) {
+		if ( null !== $this->call_to_action ) {
 			$cta              = $raw_content['cta'];
 			$cta['title']     = $cta['title'] ?: __( 'Read more', 'hogan-content-grid' );
 			$cta['classname'] = apply_filters( 'hogan/module/banner/cta_css_classes', '', $this );


### PR DESCRIPTION
If an item in the grid doesn't have a link or image set, it got the image/link from the previous item because $this->call_to_action / $this->image was not reset for every item in the raw_content array.

Not sure if this is the right solution. Should maybe get_provider() return a new instance of the provider?

Issue causes a bug for Brukhue which is set to be lauched very soon.